### PR TITLE
installs libsqlite3-dev

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -14,6 +14,7 @@
     - libyaml-dev
     - libxml2-dev
     - libxslt1-dev
+    - libsqlite3-dev
     - autoconf
     - libc6-dev
     - libncurses5-dev


### PR DESCRIPTION
I used this playbook as a basis for another playbook, but my `bundle install` failed because I didn't have this library installed.
